### PR TITLE
Add support for custom rails environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2019-09-10
+### Added
+- Rails/UnknownEnv cop
+- Include custom environments: review + staging
+
 ## [1.0.0] - 2019-08-28
 ### Added
 - Default rubocop config

--- a/default.yml
+++ b/default.yml
@@ -63,6 +63,14 @@ Rails:
 Rails/HttpPositionalArguments:
   Enabled: false
 
+Rails/UnknownEnv:
+  Environments:
+    - production
+    - staging
+    - development
+    - test
+    - review
+
 Rails/SkipsModelValidations:
   Whitelist:
     - touch

--- a/default.yml
+++ b/default.yml
@@ -70,6 +70,8 @@ Rails/UnknownEnv:
     - development
     - test
     - review
+    - api-production
+    - api-staging
 
 Rails/SkipsModelValidations:
   Whitelist:

--- a/lib/netsoft/rubocop/version.rb
+++ b/lib/netsoft/rubocop/version.rb
@@ -2,6 +2,6 @@
 
 module Netsoft
   module Rubocop
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end


### PR DESCRIPTION
It seems that `review` is not taken into consideration as a valid environment in rubocop
https://circleci.com/gh/NetsoftHoldings/hubstaff-server/55926

Adjusted the default.yml file following this https://github.com/rubocop-hq/rubocop/issues/4956#issuecomment-340235408