### PR TITLE
fix(Layout/IndentAssignment): remove config

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -35,9 +35,6 @@ Layout/AlignHash:
 Layout/ExtraSpacing:
   AllowForAlignment: true
 
-Layout/IndentAssignment:
-  IndentationWidth: 4
-
 Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
   IndentationWidth: 4


### PR DESCRIPTION
Remove the config to pass default examples of the cop
https://www.rubydoc.info/gems/rubocop/0.61.1/RuboCop/Cop/Layout/IndentAssignment

From the cop doc:

```ruby
# bad
value =
if foo
  'bar'
end

# good
value =
  if foo
    'bar'
  end
```

See the "good" variant that cannot be passed now due to the `IndentationWidth` set to 4.

If its complete removal doesn't work, I suggest to set it to 2. That would allow to write the following code:

```ruby
    managed_active_locations =
      active_locations.where(projects: {organization_id: org_ids_managed})
        .joins(
          p_t.join(uo_t).on(
            p_t[:organization_id].eq(uo_t[:organization_id])
              .and(l_t[:user_id].eq(uo_t[:user_id]))
              .and(uo_t[:status].eq(UserOrganization::Active))
          ).join_sources
        )
```

Currently it accepts only this variant:

```ruby
    managed_active_locations = active_locations.where(projects: {organization_id: org_ids_managed})
                                .joins(
                                  p_t.join(uo_t).on(
                                    p_t[:organization_id].eq(uo_t[:organization_id])
                                      .and(l_t[:user_id].eq(uo_t[:user_id]))
                                      .and(uo_t[:status].eq(UserOrganization::Active))
                                  ).join_sources
                                )

```

that's much worse than the previous example IMO: reading is a bit harder, it takes maintenance time (align for even indent length is not supported in most editors, at least out of box).

Going further, compare:

```ruby
managed_active_locations = active_locations.where(projects: {organization_id: org_ids_managed})
                             .joins(
                               p_t.join(uo_t).on(
                                 p_t[:organization_id].eq(uo_t[:organization_id])
                                   .and(l_t[:user_id].eq(uo_t[:user_id]))
                                   .and(uo_t[:status].eq(UserOrganization::Active))
                               ).join_sources
                             )
managed_passive_locations = passive_locations.where(organization_id: org_ids_managed)
                              .joins(
                                pl_t.join(uo_t).on(
                                  pl_t[:organization_id].eq(uo_t[:organization_id])
                                      .and(pl_t[:user_id].eq(uo_t[:user_id]))
                                      .and(uo_t[:status].eq(UserOrganization::Active))
                                ).join_sources
                              )
```

and 

```ruby
managed_active_locations =
  active_locations.where(projects: {organization_id: org_ids_managed})
    .joins(
      p_t.join(uo_t).on(
        p_t[:organization_id].eq(uo_t[:organization_id])
          .and(l_t[:user_id].eq(uo_t[:user_id]))
          .and(uo_t[:status].eq(UserOrganization::Active))
      ).join_sources
    )
managed_passive_locations =
  passive_locations.where(organization_id: org_ids_managed)
    .joins(
      pl_t.join(uo_t).on(
        pl_t[:organization_id].eq(uo_t[:organization_id])
            .and(pl_t[:user_id].eq(uo_t[:user_id]))
            .and(uo_t[:status].eq(UserOrganization::Active))
      ).join_sources
    )
```

see how the code indentation is not consistent with the currently forced Rubocop config.