### PR TITLE
chore: Update rubocop Jan 2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 
+## [1.1.4] - 2022-01-26
+### Changed
+- update rubocop, and rubocop-[everything] to latest versions
+
+
 ## [1.1.3] - 2021-05-10
 ### Changed
 - update rubocop, and rubocop-[everything] to latest versions

--- a/config/default.yml
+++ b/config/default.yml
@@ -22,6 +22,11 @@ AllCops:
     - 'gemfiles/**/*'
     - 'node_modules/**/*'
 
+# Checks that the gemspec has metadata to require MFA from RubyGems
+# Irrelevant for internal gems
+Gemspec/RequireMFA:
+  Enabled: false
+
 # region Layout
 Layout/AssignmentIndentation:
   IndentationWidth: 4
@@ -51,6 +56,15 @@ Layout/SpaceInsideHashLiteralBraces:
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/**/*
+
+# Requires to change `foo + bar * baz` into `foo + (bar * baz)` for clarity. WHAT.
+Lint/AmbiguousOperatorPrecedence:
+  Enabled: false
+
+# Prohibits ranges like 1.minute..5.minutes, and wants them to look like (1.minute)..(5.minutes)
+# Please no.
+Lint/AmbiguousRange:
+  Enabled: false
 
 Lint/NonDeterministicRequireOrder:
   Enabled: false
@@ -98,6 +112,11 @@ Naming/VariableNumber:
 # endregion
 
 # region Performance
+# Wants to convert 0.to_d into BigDecimal.new('0'), which is ugly and doesn't actually do anything
+# to "improve performance"
+Performance/BigDecimalWithNumericArgument:
+  Enabled: false
+
 Performance/CollectionLiteralInLoop:
   Enabled: false
 
@@ -132,6 +151,15 @@ Rails/HttpPositionalArguments:
 
 Rails/HttpStatus:
   EnforcedStyle: numeric
+
+# The cop states that if you have `belongs_to :organization`, the validator is added automatically,
+# so you don't need `validates :organization, presence: true` (or `validates :organization_id`).
+#
+# I (zverok) checked it on our codebase and it is not true. Should be clarified later, maybe our
+# Rails version is too old?..
+#
+Rails/RedundantPresenceValidationOnBelongsTo:
+  Enabled: false
 
 Rails/SkipsModelValidations:
   AllowedMethods:
@@ -253,6 +281,21 @@ Style/MultilineBlockChain:
 # We need to develop our own .deep_freeze for configs, and cops to check that it is attached to
 # hashes, arrays and values fetched from ENV/configs.
 Style/MutableConstant:
+  Enabled: false
+
+# Allows them only in single-line blocks. Doesn't really help!
+Style/NumberedParameters:
+  Enabled: false
+
+Style/NumberedParametersLimit:
+  Max: 2
+
+# Just prohibits OpenStruct forever. Technically reasonable, but when we use it, we know what we do
+Style/OpenStructUse:
+  Enabled: false
+
+# Asks to change `"foo-bar": baz` to `'foo-bar': baz`. Lots of changes, little value
+Style/QuotedSymbols:
   Enabled: false
 
 Style/ParallelAssignment:

--- a/lib/netsoft/rubocop/version.rb
+++ b/lib/netsoft/rubocop/version.rb
@@ -2,6 +2,6 @@
 
 module Netsoft
   module Rubocop
-    VERSION = '1.1.3'
+    VERSION = '1.1.4'
   end
 end

--- a/netsoft-rubocop.gemspec
+++ b/netsoft-rubocop.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '>= 12.0'
 
-  spec.add_runtime_dependency 'rubocop', '= 1.14.0'
-  spec.add_runtime_dependency 'rubocop-performance', '= 1.11.3'
-  spec.add_runtime_dependency 'rubocop-rails', '= 2.10.1'
-  spec.add_runtime_dependency 'rubocop-rake', '= 0.5.1'
-  spec.add_runtime_dependency 'rubocop-rspec', '= 2.3.0'
+  spec.add_runtime_dependency 'rubocop', '= 1.25.0'
+  spec.add_runtime_dependency 'rubocop-performance', '= 1.13.2'
+  spec.add_runtime_dependency 'rubocop-rails', '= 2.13.2'
+  spec.add_runtime_dependency 'rubocop-rake', '= 0.6.0'
+  spec.add_runtime_dependency 'rubocop-rspec', '= 2.7.0'
 end


### PR DESCRIPTION
New cops checked on hubstaff-server, its PR will follow

## Related issues

- Source: —
- UAT: —
- QA: —
- Review app:—

## Checklists

### Development

- [x] The commit message follows our [guidelines](https://docs.hubstaff.com/hubstaff-docs/latest/great_commit_messages.html)
- [x] I have performed a self-review of my own code
- [x] I have thoroughly tested the changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Security

- [x] Security impact of change has been considered
