### PR TITLE
feat(Layout/IndentAssignment): explicitly set config to be 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 
+## [1.1.5] - 2022-03-18
+### Changed
+- adjust assignment indent rule to be default 2 space indent
+
 ## [1.1.4] - 2022-01-26
 ### Changed
 - update rubocop, and rubocop-[everything] to latest versions
-
 
 ## [1.1.3] - 2021-05-10
 ### Changed

--- a/config/default.yml
+++ b/config/default.yml
@@ -29,7 +29,7 @@ Gemspec/RequireMFA:
 
 # region Layout
 Layout/AssignmentIndentation:
-  IndentationWidth: 4
+  IndentationWidth: 2
 
 Layout/ExtraSpacing:
   AllowForAlignment: true

--- a/lib/netsoft/rubocop/version.rb
+++ b/lib/netsoft/rubocop/version.rb
@@ -2,6 +2,6 @@
 
 module Netsoft
   module Rubocop
-    VERSION = '1.1.4'
+    VERSION = '1.1.5'
   end
 end


### PR DESCRIPTION
## Change description
Explicit set IndentAssignment to be 2. 
If not, the default will not be shown in `--show-cops`
```shell
rubocop --show-cops Layout/AssignmentIndentation
# Supports --auto-correct
Layout/AssignmentIndentation:
  Description: Checks the indentation of the first line of the right-hand-side of a
    multi-line assignment.
  Enabled: true
  VersionAdded: '0.49'
  VersionChanged: '0.77'
  IndentationWidth:  
```

## Related issues

- Source: https://tasks.hubstaff.com/app/organizations/55/sprints/tasks/2564308
- Slack Discussion: https://netsoftllc.slack.com/archives/C02AMSXHH2P/p1638869672054200
- Previous PR initiated by @ka8725: https://github.com/NetsoftHoldings/netsoft-rubocop/pull/7
- https://github.com/NetsoftHoldings/netsoft-rubocop/pull/17#pullrequestreview-860800478

## Checklists

### Development

- [x] The commit message follows our [guidelines](https://docs.hubstaff.com/hubstaff-docs/latest/great_commit_messages.html)
- [x] I have performed a self-review of my own code
- [x] I have thoroughly tested the changes
- (n/a) I have added tests that prove my fix is effective or that my feature works

### Security

- [x] Security impact of change has been considered
