### PR TITLE
fix: Development gems dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 
+## [1.1.8] - 2023-12-12
+### Fixed
+- fix dependency on gems that are only necessary for CI
+
 ## [1.1.7] - 2023-10-18
 ### Changed
 - update rubocop, and rubocop-[everything] to latest versions

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,13 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gemspec
 
-group :development do
+group :development, :test do
   gem 'rake', '>= 12.0'
+
+  # These versions come by default with Ruby 3.2. If we don't specify them,
+  # Ruby will try to install the newest, which requires C compiler, which
+  # fails currently on our CI.
+  gem 'bigdecimal', '<= 3.1.3'
+  gem 'json', '<= 2.6.3'
+  gem 'racc', '<= 1.6.2'
 end

--- a/lib/netsoft/rubocop/version.rb
+++ b/lib/netsoft/rubocop/version.rb
@@ -2,6 +2,6 @@
 
 module Netsoft
   module Rubocop
-    VERSION = '1.1.7'
+    VERSION = '1.1.8'
   end
 end

--- a/netsoft-rubocop.gemspec
+++ b/netsoft-rubocop.gemspec
@@ -23,12 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7' # rubocop: disable Gemspec/RequiredRubyVersion
 
-  # These versions come by default with Ruby 3.2. If we don't specify them,
-  # Ruby will try to install the newest, which requires C compiler, which
-  # fails currently on our CI.
-  spec.add_runtime_dependency 'bigdecimal', '<= 3.1.3'
-  spec.add_runtime_dependency 'racc', '<= 1.6.2'
-
   # NB: Do not update to 1.57.1, it has a bug: https://github.com/rubocop/rubocop/issues/12275
   spec.add_runtime_dependency 'rubocop', '= 1.57.0'
   spec.add_runtime_dependency 'rubocop-graphql', '= 1.1.1'


### PR DESCRIPTION
The adjustment made for Ruby 3.2 not to fail on CI was too eager a dependency.

## Checklists

### Development

- [ ] The commit message follows our [guidelines](https://docs.hubstaff.com/hubstaff-docs/latest/great_commit_messages.html)
- [ ] I have performed a self-review of my own code
- [ ] I have thoroughly tested the changes
- [ ] I have added tests that prove my fix is effective or that my feature works

### Security

- [ ] Security impact of change has been considered
