### PR TITLE
chore: Update rubocop and related gems (June 2024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 
+## [1.1.9] - 2024-06-17
+### Changed
+- update rubocop, and rubocop-[everything] to latest possible versions that support Ruby 2
+- add new rules according to new cops emerged
+
 ## [1.1.8] - 2023-12-12
 ### Fixed
 - fix dependency on gems that are only necessary for CI

--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ group :development, :test do
   gem 'bigdecimal', '<= 3.1.3'
   gem 'json', '<= 2.6.3'
   gem 'racc', '<= 1.6.2'
+  gem 'strscan', '<= 3.0.5'
 end

--- a/config/default.yml
+++ b/config/default.yml
@@ -5,6 +5,7 @@ require:
   - rubocop-rspec
   - rubocop-rake
   - rubocop-capybara
+  - rubocop-rspec_rails
   - rubocop-factory_bot
   - rubocop-graphql
 
@@ -251,8 +252,24 @@ RSpec/SortMetadata:
   Enabled: false
 
 # Same as for Rails/HttpStatus
-RSpec/Rails/HttpStatus:
+RSpecRails/HttpStatus:
   EnforcedStyle: numeric
+
+# Limits an amount of items created by `create_list`. This should be a human decision on review, not
+# mechanical limitation.
+FactoryBot/ExcessiveCreateList:
+  Enabled: false
+
+# Prohibits literals like numbers in the descriptions; which might sometimes be useful, and also conflicts
+# with `its_call(number)` (which it understands like a description).
+RSpec/UndescriptiveLiteralsDescription:
+  Enabled: false
+
+# Enforces either `to have_no_selector` (the default) or `to_not have_selector` (a setting).
+# We use the latter in our codebase, but there is no reason to strictly prohibit the former (it
+# might be used in chains), so no biggie.
+Capybara/NegationMatcher:
+  Enabled: false
 
 # endregion
 

--- a/lib/netsoft/rubocop/version.rb
+++ b/lib/netsoft/rubocop/version.rb
@@ -2,6 +2,6 @@
 
 module Netsoft
   module Rubocop
-    VERSION = '1.1.8'
+    VERSION = '1.1.9'
   end
 end

--- a/netsoft-rubocop.gemspec
+++ b/netsoft-rubocop.gemspec
@@ -23,11 +23,17 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7' # rubocop: disable Gemspec/RequiredRubyVersion
 
-  # NB: Do not update to 1.57.1, it has a bug: https://github.com/rubocop/rubocop/issues/12275
-  spec.add_runtime_dependency 'rubocop', '= 1.57.0'
+  spec.add_runtime_dependency 'rubocop', '= 1.64.1'
+  # TODO: The next version dropped support for Ruby < 2, can be updated when all of our projects
+  # are on Ruby 3+
   spec.add_runtime_dependency 'rubocop-graphql', '= 1.1.1'
-  spec.add_runtime_dependency 'rubocop-performance', '= 1.19.1'
-  spec.add_runtime_dependency 'rubocop-rails', '= 2.21.2'
+  spec.add_runtime_dependency 'rubocop-performance', '= 1.21.0'
+  spec.add_runtime_dependency 'rubocop-rails', '= 2.25.0'
   spec.add_runtime_dependency 'rubocop-rake', '= 0.6.0'
-  spec.add_runtime_dependency 'rubocop-rspec', '= 2.24.1'
+
+  spec.add_runtime_dependency 'rubocop-rspec', '= 3.0.1'
+  # Gems extracted from rubocop-rspec as separate projects:
+  spec.add_runtime_dependency 'rubocop-capybara', '= 2.21.0'
+  spec.add_runtime_dependency 'rubocop-factory_bot', '= 2.26.1'
+  spec.add_runtime_dependency 'rubocop-rspec_rails', '= 2.30.0'
 end


### PR DESCRIPTION
Updates all gems to the newest versions, where possible; adjusts config defaults accordingly.

Corresponding Server PR: https://github.com/NetsoftHoldings/hubstaff-server/pull/12136

## Related issues

- Source: [HUB-3786](https://netsoftllc.atlassian.net/browse/HUB-3786)

## Checklists

### Development

- [x] The commit message follows our [guidelines](https://docs.hubstaff.com/hubstaff-docs/latest/great_commit_messages.html)
- [x] I have performed a self-review of my own code
- [x] I have thoroughly tested the changes
- [x] I have added tests that prove my fix is effective or that my feature works

### Security

- [x] Security impact of change has been considered
